### PR TITLE
Calls super._mint directly

### DIFF
--- a/contracts/DecentralizedAutonomousTrust.sol
+++ b/contracts/DecentralizedAutonomousTrust.sol
@@ -881,7 +881,7 @@ contract DecentralizedAutonomousTrust is ERC20, ERC20Detailed {
   }
 
   function mint(address to, uint256 amount) public onlyControl {
-    _mint(to, amount);
+     super._mint(to, amount);
   }
 
   /**


### PR DESCRIPTION
rather than redundantly calling into internal _mint function, which has some bonding curve logic to it, just call right into super._mint