### PR TITLE
chore: audit G1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Extends [DXtrust's DAT](https://github.com/levelkdev/dxtrust) implementation wit
 
 - `withdrawETH` to withdraw ETH from the contract to the beneficiary.
 - `withdrawToken(address token)` to withdraw any ERC20 token from the contract to the beneficiary.
-- `burnFrom(address account, uint256 amount)` to burn the DXD tokens, callable only by the owner.
+- `saveVestedTokens(ITokenVesting tokenVesting)` to burn the DXD tokens in vesting contracts, and mint the same amount of DXD tokens to the respective beneficiary.
 
 Tests cover the following scenarios:
 

--- a/contracts/DecentralizedAutonomousTrust.sol
+++ b/contracts/DecentralizedAutonomousTrust.sol
@@ -9,6 +9,7 @@ import '@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol
 import '@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20Detailed.sol';
 import '@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol';
 import '@openzeppelin/contracts-ethereum-package/contracts/utils/Address.sol';
+import './interfaces/ITokenVesting.sol';
 
 /**
  * @title Decentralized Autonomous Trust
@@ -880,16 +881,16 @@ contract DecentralizedAutonomousTrust is ERC20, ERC20Detailed {
     require(sent, 'Failed to send Ether');
   }
 
-  function mint(address to, uint256 amount) public onlyControl {
-     super._mint(to, amount);
-  }
-
   /**
-   * Burns tokens from account
-   * @param account account address
-   * @param amount amount to mint
+   * Saves vested token in vesting contract to the vesting beneficiary
+   * Used to accelerate vesting
+   * @param tokenVesting token vesting contract
    */
-  function burnFrom(address account, uint256 amount) public onlyControl {
-    _burn(account, amount, false);
+  function saveVestedTokens(ITokenVesting tokenVesting) public onlyControl {
+    uint256 tokenVestingBalance = balanceOf(address(tokenVesting));
+    require(tokenVestingBalance > 0, "DAT: No vested tokens to save");
+    // Burn from the vesting contract and mint to the beneficiary
+    super._burn(address(tokenVesting), tokenVestingBalance);
+    super._mint(tokenVesting.beneficiary(), tokenVestingBalance);
   }
 }

--- a/contracts/DecentralizedAutonomousTrust.sol
+++ b/contracts/DecentralizedAutonomousTrust.sol
@@ -886,11 +886,10 @@ contract DecentralizedAutonomousTrust is ERC20, ERC20Detailed {
    * Used to accelerate vesting
    * @param tokenVesting token vesting contract
    */
-  function saveVestedTokens(ITokenVesting tokenVesting) public onlyControl {
+  function saveVestedTokens(ITokenVesting tokenVesting) external onlyControl {
     uint256 tokenVestingBalance = balanceOf(address(tokenVesting));
     require(tokenVestingBalance > 0, "DAT: No vested tokens to save");
     // Burn from the vesting contract and mint to the beneficiary
-    super._burn(address(tokenVesting), tokenVestingBalance);
-    super._mint(tokenVesting.beneficiary(), tokenVestingBalance);
+    _transfer(address(tokenVesting), tokenVesting.beneficiary(), tokenVestingBalance);
   }
 }

--- a/contracts/interfaces/ITokenVesting.sol
+++ b/contracts/interfaces/ITokenVesting.sol
@@ -1,0 +1,8 @@
+pragma solidity 0.5.17;
+
+/**
+ * @title TokenVesting interface
+ */
+interface ITokenVesting {
+  function beneficiary() external view returns (address);
+}


### PR DESCRIPTION

> Recommendation: Remove the new mint and burnFrom functions, and instead add more limited functionality that . There are many ways of doing that; one, for example, is by defining a function saveVestedToken(from, to) onlyControl that allows the control address to transfer tokens between two addresses, so the total supply is guaranteed to stay the same. In addition, logic can be added that makes it likely that the first address is the address of  a DXD vesting contract, which will never change the total supply
