### PR TITLE
chore: audit G2 and G3

### DIFF
--- a/contracts/DecentralizedAutonomousTrust.sol
+++ b/contracts/DecentralizedAutonomousTrust.sol
@@ -544,6 +544,7 @@ contract DecentralizedAutonomousTrust is ERC20, ERC20Detailed {
   /// @dev _minTokensBought is necessary as the price will change if some elses transaction mines after
   /// yours was submitted.
   function buy(address _to, uint _currencyValue, uint _minTokensBought) public payable {
+    require(false, 'DAT: disabled');
     require(_to != address(0), 'INVALID_ADDRESS');
     require(_minTokensBought > 0, 'MUST_BUY_AT_LEAST_1');
 
@@ -656,6 +657,7 @@ contract DecentralizedAutonomousTrust is ERC20, ERC20Detailed {
   /// @dev _minCurrencyReturned is necessary as the price will change if some elses transaction mines after
   /// yours was submitted.
   function sell(address payable _to, uint _quantityToSell, uint _minCurrencyReturned) public {
+    require(false, 'DAT: disabled');
     require(msg.sender != beneficiary || state >= STATE_CLOSE, 'BENEFICIARY_ONLY_SELL_IN_CLOSE_OR_CANCEL');
     require(_minCurrencyReturned > 0, 'MUST_SELL_AT_LEAST_1');
 
@@ -753,6 +755,7 @@ contract DecentralizedAutonomousTrust is ERC20, ERC20Detailed {
   /// is not authorized to receive tokens then they will be sent to the beneficiary account instead.
   /// @param _currencyValue How much currency which was paid.
   function pay(address _to, uint _currencyValue) public payable {
+    require(false, 'DAT: disabled');
     _collectInvestment(_currencyValue, msg.value, false);
     _pay(_to, _currencyValue);
   }
@@ -888,7 +891,7 @@ contract DecentralizedAutonomousTrust is ERC20, ERC20Detailed {
    */
   function saveVestedTokens(ITokenVesting tokenVesting) external onlyControl {
     uint256 tokenVestingBalance = balanceOf(address(tokenVesting));
-    require(tokenVestingBalance > 0, "DAT: No vested tokens to save");
+    require(tokenVestingBalance > 0, 'DAT: No vested tokens to save');
     // Burn from the vesting contract and mint to the beneficiary
     _transfer(address(tokenVesting), tokenVesting.beneficiary(), tokenVestingBalance);
   }

--- a/test/poc.spec.ts
+++ b/test/poc.spec.ts
@@ -179,4 +179,15 @@ describe('DXD upgrade and Withdrwals', function () {
       'DAT: ONLY_CONTROL'
     );
   });
+
+  it('pay, buy and sell are disabled', async function () {
+    const datProxyFromClosureSafe = await ethers.getContractAt(
+      'DecentralizedAutonomousTrust',
+      DAT_PROXY,
+      dxdaoClosureSafeSigner
+    );
+    await expect(datProxyFromClosureSafe.buy(DXDAO_CLOSURE_SAFE, 1, 1)).to.be.revertedWith('DAT: disabled');
+    await expect(datProxyFromClosureSafe.sell(DXDAO_CLOSURE_SAFE, 1, 1)).to.be.revertedWith('DAT: disabled');
+    await expect(datProxyFromClosureSafe.pay(DXDAO_CLOSURE_SAFE, 1)).to.be.revertedWith('DAT: disabled');
+  });
 });


### PR DESCRIPTION
> Recommendation: The only viable attack vector here is a griefing attack in which the atacker mints new DXD and redeems it, thereby excluding other DXD holders from the redeem process. However, such an attack would be very costly, as the price quoted by the pay function is quite high relative to the underlying value., so it is not likely to occur. Users could of course mint new tokens by accident.In any case, there is no reason to maintain this functionality, and we recommend to disable the function or remove it from the code base altogether.

> Recommendation: As part of the upgrade process, redefine the buy and sell functions, such that they always revert with a clear error. Alternatively, you can completely remove these functions as they are not needed anymore

